### PR TITLE
Pass proper options at execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,20 @@ Running 'lute' in a directory will serve that dir and set up LiveReload - no nee
 
 Serves current directory on default port (8080).  Will find an open port if it's not available
 
-`$ lute -p 3000`
-
-`-p` option specifies a specific port. Executing this serves current directory on 3000, will find an open port if not available
-
 `$ lute open`
 
 Serves current dir and opens in your browser
+
+### Options
+
+`$ lute -p 3000`
+
+This serves current directory on port 3000 - will find an open port if 3000 is not available
+
+`$ lute -i bower_components`
+
+This will ignore `bower_components` when watching for changes, relative to the path `lute` is launched from - use a comma-delimited list to pass multiple paths
+
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Information
 
 <table>
-<tr> 
+<tr>
 <td>Package</td><td>lute</td>
 </tr>
 <tr>
@@ -28,13 +28,13 @@ Running 'lute' in a directory will serve that dir and set up LiveReload - no nee
 
 Serves current directory on default port (8080).  Will find an open port if it's not available
 
-`$ lute 3000`
+`$ lute -p 3000`
 
-Serves current directory on 3000, will find an open port if not available
+`-p` option specifies a specific port. Executing this serves current directory on 3000, will find an open port if not available
 
 `$ lute open`
 
-Serves current dir and opens in your browser 
+Serves current dir and opens in your browser
 
 ## TODO
 

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-var argv  = require('minimist')(process.argv.slice(2));
-var isInt = require('../lib/util/isInt');
-var serve = require('../lib/serve');
-var port  = (argv.p && isInt(argv.p)) ? argv.p : 8080;
+var argv        = require('minimist')(process.argv.slice(2));
+var isInt       = require('../lib/util/isInt');
+var serve       = require('../lib/serve');
+var port        = (argv.p && isInt(argv.p)) ? argv.p : 8080;
+var browserOpen = (argv._.indexOf('open') !== -1);
 
-serve(port, argv);
+serve(port, browserOpen, argv);

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -1,23 +1,9 @@
 #!/usr/bin/env node
 
+var argv  = require('minimist')(process.argv.slice(2));
 var isInt = require('../lib/util/isInt');
 var serve = require('../lib/serve');
+var port  = (argv.p && isInt(argv.p)) ? argv.p : 8080;
 
-var cliArgs = process.argv.slice(2);
-var port    = isInt(cliArgs[0]) ? cliArgs[0] : 8080;
-
-// if a port or no args, start server 
-
-if ( isInt(cliArgs[0]) || typeof cliArgs[0] === 'undefined') {
-
-  // just start server & live reload 
-
-  serve(port);
-
-}
-
-if (cliArgs[0] === 'open') {
-
-  serve(port, true);
-
-}
+// if a port or no args, start server
+serve(port, (argv._.indexOf('open') !== -1));

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -5,4 +5,4 @@ var isInt = require('../lib/util/isInt');
 var serve = require('../lib/serve');
 var port  = (argv.p && isInt(argv.p)) ? argv.p : 8080;
 
-serve(port, (argv._.indexOf('open') !== -1), argv);
+serve(port, argv);

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -5,5 +5,4 @@ var isInt = require('../lib/util/isInt');
 var serve = require('../lib/serve');
 var port  = (argv.p && isInt(argv.p)) ? argv.p : 8080;
 
-// if a port or no args, start server
-serve(port, (argv._.indexOf('open') !== -1));
+serve(port, (argv._.indexOf('open') !== -1), argv);

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -2,11 +2,11 @@ var createLiveReload = require('./createLiveReload');
 var createServer     = require('./createServer');
 var watch            = require('./watch');
 
-module.exports = function(port, open) {
+module.exports = function(port, open, argv) {
 
   createLiveReload(function(err, liveReload, lrPort){
     createServer(port, lrPort, open, function(err, server){
-      watch(liveReload);
+      watch(liveReload, argv);
     });
   });
 

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -2,11 +2,18 @@ var createLiveReload = require('./createLiveReload');
 var createServer     = require('./createServer');
 var watch            = require('./watch');
 
-module.exports = function(port, open, argv) {
+module.exports = function(port, argv) {
+  var open        = (argv._.indexOf('open') !== -1);
+  var watchPaths  = ["./**/*", "!./node_modules/**/*"];
+  var ignorePaths = (argv.i) ? argv.i.split(',') : [];
+
+  for(var i=0; i<ignorePaths.length; i++) {
+    watchPaths.push("!./" + ignorePaths[i] + '/**/*');
+  }
 
   createLiveReload(function(err, liveReload, lrPort){
     createServer(port, lrPort, open, function(err, server){
-      watch(liveReload, argv);
+      watch(liveReload, watchPaths);
     });
   });
 

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -2,10 +2,9 @@ var createLiveReload = require('./createLiveReload');
 var createServer     = require('./createServer');
 var watch            = require('./watch');
 
-module.exports = function(port, argv) {
-  var open        = (argv._.indexOf('open') !== -1);
+module.exports = function(port, open, options) {
   var watchPaths  = ["./**/*", "!./node_modules/**/*"];
-  var ignorePaths = (argv.i) ? argv.i.split(',') : [];
+  var ignorePaths = (options.i) ? options.i.split(',') : [];
 
   for(var i=0; i<ignorePaths.length; i++) {
     watchPaths.push("!./" + ignorePaths[i] + '/**/*');

--- a/lib/serve/watch.js
+++ b/lib/serve/watch.js
@@ -3,7 +3,7 @@ var gutil = require('gulp-util');
 
 module.exports = function(liveReload) {
 
-  gulp.watch(["./**/*", "!./node_modules/**/*"], function(evt){
+  gulp.watch(["./**/*", "!./node_modules/**/*", "!./bower_components/**/*"], function(evt){
 
     gutil.log(gutil.colors.cyan(evt.path), 'changed');
 

--- a/lib/serve/watch.js
+++ b/lib/serve/watch.js
@@ -1,9 +1,15 @@
 var gulp  = require('gulp');
 var gutil = require('gulp-util');
 
-module.exports = function(liveReload) {
+module.exports = function(liveReload, argv) {
 
-  gulp.watch(["./**/*", "!./node_modules/**/*", "!./bower_components/**/*"], function(evt){
+  var paths = ["./**/*", "!./node_modules/**/*"];
+  var ignorePaths = (argv.i) ? argv.i.split(',') : [];
+  for(var i=0; i<ignorePaths.length; i++) {
+    paths.push("!./" + ignorePaths[i] + '/**/*');
+  }
+
+  gulp.watch(paths, function(evt){
 
     gutil.log(gutil.colors.cyan(evt.path), 'changed');
 

--- a/lib/serve/watch.js
+++ b/lib/serve/watch.js
@@ -1,13 +1,7 @@
 var gulp  = require('gulp');
 var gutil = require('gulp-util');
 
-module.exports = function(liveReload, argv) {
-
-  var paths = ["./**/*", "!./node_modules/**/*"];
-  var ignorePaths = (argv.i) ? argv.i.split(',') : [];
-  for(var i=0; i<ignorePaths.length; i++) {
-    paths.push("!./" + ignorePaths[i] + '/**/*');
-  }
+module.exports = function(liveReload, paths) {
 
   gulp.watch(paths, function(evt){
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express": "~3.4.7",
     "gulp-util": "~2.2.0",
     "portfinder": "~0.2.1",
-    "cheerio": "~0.13.1"
+    "cheerio": "~0.13.1",
+    "minimist": "0.0.8"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Uses flag at execution
- `-p` is used to specify the port
- `-i` is used to ignore paths for the watch process

Updated README to reflect these changes
