### PR TITLE
Refactor option parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,38 @@ Running 'lute' in a directory will serve that dir and set up LiveReload - no nee
 
 `$ lute`
 
-Serves current directory on default port (8080).  Will find an open port if it's not available
-
-`$ lute open`
-
-Serves current dir and opens in your browser
+Serves current directory on default port (8080).  Will find an open port if it's not available.
 
 ### Options
 
-`$ lute -p 3000`
-
-This serves current directory on port 3000 - will find an open port if 3000 is not available
-
-`$ lute -i bower_components`
-
-This will ignore `bower_components` when watching for changes, relative to the path `lute` is launched from - use a comma-delimited list to pass multiple paths
-
+<table>
+<tr>
+<td>Flag</td><td>Default</td><td>Description</td>
+</tr>
+<tr>
+<td>-o</td>
+<td></td>
+<td>Opens your browser</td>
+</tr>
+<tr>
+<td>-i</td>
+<td></td>
+<td>Set paths to ignore when using the watcher, relative to the path `lute` is launched from (use a comma-delimited list to pass multiple paths)
+</td>
+</tr>
+<tr>
+<td>-p</td>
+<td>8080</td>
+<td>Select the port to serve the site on, will find an open port if not available
+</td>
+</tr>
+<tr>
+<td>-l</td>
+<td>35729</td>
+<td>Select the port for live-reload, will find an open port if not available
+</td>
+</tr>
+</table>
 
 ## TODO
 

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
-var argv        = require('minimist')(process.argv.slice(2));
-var isInt       = require('../lib/util/isInt');
-var serve       = require('../lib/serve');
-var port        = (argv.p && isInt(argv.p)) ? argv.p : 8080;
-var browserOpen = (argv._.indexOf('open') !== -1);
+var argv         = require('minimist')(process.argv.slice(2));
+var parseOptions = require('../lib/util/parseOptions');
+var serve        = require('../lib/serve');
 
-serve(port, browserOpen, argv);
+serve(parseOptions(argv));

--- a/bin/lute.js
+++ b/bin/lute.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-var argv         = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(process.argv.slice(2));
 var parseOptions = require('../lib/util/parseOptions');
-var serve        = require('../lib/serve');
+var serve = require('../lib/serve');
 
 serve(parseOptions(argv));

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  httpPort: 8080,
+  lrPort: 35729
+};

--- a/lib/serve/createLiveReload.js
+++ b/lib/serve/createLiveReload.js
@@ -1,16 +1,13 @@
 var tinylr = require('tiny-lr');
-var pf     = require('portfinder');
+var pf = require('portfinder');
 
 module.exports = function (port, next) {
   var lr = tinylr();
 
   pf.getPort({port: port}, function(err, lrPort){
-
     lr.listen(lrPort, function() {
       console.log('LR Listening on port', lrPort);
       next(null, lr, lrPort);
     });
-
   });
-
 };

--- a/lib/serve/createLiveReload.js
+++ b/lib/serve/createLiveReload.js
@@ -1,16 +1,13 @@
 var tinylr = require('tiny-lr');
 var pf     = require('portfinder');
 
-module.exports = function (next) {
-
-  var port = 35729;
-
+module.exports = function (port, next) {
   var lr = tinylr();
 
   pf.getPort({port: port}, function(err, lrPort){
 
     lr.listen(lrPort, function() {
-      console.log('LR Listening on', lrPort);
+      console.log('LR Listening on port', lrPort);
       next(null, lr, lrPort);
     });
 

--- a/lib/serve/createServer.js
+++ b/lib/serve/createServer.js
@@ -1,9 +1,9 @@
-var path     = require('path');
-var url      = require('url');
-var http     = require('http');
-var pf       = require('portfinder');
-var rstream  = require('replacestream');
-var send     = require('send');
+var path = require('path');
+var url = require('url');
+var http = require('http');
+var pf = require('portfinder');
+var rstream = require('replacestream');
+var send = require('send');
 
 module.exports = function (port, next) {
   var root = path.resolve(process.cwd());

--- a/lib/serve/createServer.js
+++ b/lib/serve/createServer.js
@@ -4,9 +4,8 @@ var http     = require('http');
 var pf       = require('portfinder');
 var rstream  = require('replacestream');
 var send     = require('send');
-var openIt   = require('open');
 
-module.exports = function (port, lrPort, open, next) {
+module.exports = function (port, next) {
   var root = path.resolve(process.cwd());
 
   var server = http.createServer(function(req, res) {
@@ -25,11 +24,8 @@ module.exports = function (port, lrPort, open, next) {
   // find available http port
   pf.getPort({port: port}, function(err, httpPort){
     server.listen(httpPort, function() {
-      console.log('Listening on', httpPort);
-      if (open) {
-        openIt('http://localhost:'+httpPort);
-      }
-      next(null, server);
+      console.log('Listening on port', httpPort);
+      next(null, server, httpPort);
     });
 
   });

--- a/lib/serve/createServer.js
+++ b/lib/serve/createServer.js
@@ -2,7 +2,6 @@ var path = require('path');
 var url = require('url');
 var http = require('http');
 var pf = require('portfinder');
-var rstream = require('replacestream');
 var send = require('send');
 
 module.exports = function (port, next) {

--- a/lib/serve/createServer.js
+++ b/lib/serve/createServer.js
@@ -19,20 +19,6 @@ module.exports = function (port, lrPort, open, next) {
       res.end(err.message);
     });
 
-    // this is a hack
-    /*
-    streamer.once('stream', function hookStream(realStream){
-      // if html, inject lr
-      if (path.extname(filePath).match(/\.htm(l)?$/)) {
-        var orig = realStream.pipe.bind(realStream);
-        realStream.pipe = function(newStream, opt) {
-          var replacer = rstream('</body>', getLivereloadTag(lrPort)+'</body>');
-          return orig(replacer).pipe(newStream);
-        };
-      }
-    });
-    */
-
     streamer.pipe(res);
   });
 

--- a/lib/serve/createServer.js
+++ b/lib/serve/createServer.js
@@ -30,7 +30,3 @@ module.exports = function (port, next) {
 
   });
 };
-
-function getLivereloadTag(port) {
-  return "<script>if(window.self === window.top){document.write('<script src=\"http://' + (location.host || 'localhost').split(':')[0] + ':"+port+"/livereload.js?snipver=1\"></script>')}</script>";
-}

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -4,20 +4,13 @@ var watch = require('./watch');
 var openIt = require('open');
 
 module.exports = function(options) {
-  var watchPaths  = ["./**/*", "!./node_modules/**/*"];
-  var ignorePaths = (options.i) ? options.i.split(',') : [];
-
-  for(var i=0; i<ignorePaths.length; i++) {
-    watchPaths.push("!./" + ignorePaths[i] + '/**/*');
-  }
-
   createLiveReload(options.lrPort, function(err, liveReload, lrPort){
     createServer(options.port, function(err, server, httpPort){
       if (options.open) {
         openIt('http://localhost:'+httpPort);
       }
 
-      watch(liveReload, watchPaths);
+      watch(liveReload, options.watchPaths);
     });
   });
 };

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -1,8 +1,9 @@
 var createLiveReload = require('./createLiveReload');
 var createServer     = require('./createServer');
 var watch            = require('./watch');
+var openIt           = require('open');
 
-module.exports = function(port, open, options) {
+module.exports = function(options) {
   var watchPaths  = ["./**/*", "!./node_modules/**/*"];
   var ignorePaths = (options.i) ? options.i.split(',') : [];
 
@@ -10,10 +11,13 @@ module.exports = function(port, open, options) {
     watchPaths.push("!./" + ignorePaths[i] + '/**/*');
   }
 
-  createLiveReload(function(err, liveReload, lrPort){
-    createServer(port, lrPort, open, function(err, server){
+  createLiveReload(options.lrPort, function(err, liveReload, lrPort){
+    createServer(options.port, function(err, server, httpPort){
+      if (options.open) {
+        openIt('http://localhost:'+httpPort);
+      }
+
       watch(liveReload, watchPaths);
     });
   });
-
 };

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -1,7 +1,7 @@
 var createLiveReload = require('./createLiveReload');
-var createServer     = require('./createServer');
-var watch            = require('./watch');
-var openIt           = require('open');
+var createServer = require('./createServer');
+var watch = require('./watch');
+var openIt = require('open');
 
 module.exports = function(options) {
   var watchPaths  = ["./**/*", "!./node_modules/**/*"];

--- a/lib/serve/watch.js
+++ b/lib/serve/watch.js
@@ -1,20 +1,15 @@
-var gulp  = require('gulp');
+var gulp = require('gulp');
 var gutil = require('gulp-util');
 
 module.exports = function(liveReload, paths) {
-
   gulp.watch(paths, function(evt){
-
     gutil.log(gutil.colors.cyan(evt.path), 'changed');
 
     // reload on change
-
     liveReload.changed({
       body: {
         files: [evt.path]
       }
     });
-
   });
-
 };

--- a/lib/util/isInt.js
+++ b/lib/util/isInt.js
@@ -1,4 +1,4 @@
  module.exports = function(n) {
   var parsed = parseInt(n, 10);
-  return typeof parsed === 'number' && !isNaN(parsed) && parsed % 1 == 0;
+  return typeof parsed === 'number' && !isNaN(parsed) && parsed % 1 === 0;
 };

--- a/lib/util/parseOptions.js
+++ b/lib/util/parseOptions.js
@@ -1,8 +1,9 @@
 var isInt = require('./isInt');
+var config = require('../config');
 
 module.exports = function(argv) {
-  var port = (argv.p && isInt(argv.p)) ? argv.p : 8080;
-  var lrPort = (argv.l && isInt(argv.l)) ? argv.l : 35729;
+  var port = (argv.p && isInt(argv.p)) ? argv.p : config.httpPort;
+  var lrPort = (argv.l && isInt(argv.l)) ? argv.l : config.lrPort;
   var ignorePaths = (argv.i) ? argv.i.split(',') : [];
 
   var watchPaths = ['./**/*', '!./node_modules/**/*'];

--- a/lib/util/parseOptions.js
+++ b/lib/util/parseOptions.js
@@ -3,12 +3,19 @@ var isInt = require('./isInt');
 module.exports = function(argv) {
   var port = (argv.p && isInt(argv.p)) ? argv.p : 8080;
   var lrPort = (argv.l && isInt(argv.l)) ? argv.l : 35729;
+  var ignorePaths = (argv.i) ? argv.i.split(',') : [];
+
+  var watchPaths = ["./**/*", "!./node_modules/**/*"];
+  for(var i=0; i<ignorePaths.length; i++) {
+    watchPaths.push("!./" + ignorePaths[i] + '/**/*');
+  }
 
   var open = (argv.o) ? true : false;
 
   return {
     port: port,
     lrPort: lrPort,
-    open: open
+    open: open,
+    watchPaths: watchPaths
   };
 };

--- a/lib/util/parseOptions.js
+++ b/lib/util/parseOptions.js
@@ -1,0 +1,14 @@
+var isInt = require('./isInt');
+
+module.exports = function(argv) {
+  var port = (argv.p && isInt(argv.p)) ? argv.p : 8080;
+  var lrPort = (argv.l && isInt(argv.l)) ? argv.l : 35729;
+
+  var open = (argv.o) ? true : false;
+
+  return {
+    port: port,
+    lrPort: lrPort,
+    open: open
+  };
+};

--- a/lib/util/parseOptions.js
+++ b/lib/util/parseOptions.js
@@ -5,9 +5,9 @@ module.exports = function(argv) {
   var lrPort = (argv.l && isInt(argv.l)) ? argv.l : 35729;
   var ignorePaths = (argv.i) ? argv.i.split(',') : [];
 
-  var watchPaths = ["./**/*", "!./node_modules/**/*"];
+  var watchPaths = ['./**/*', '!./node_modules/**/*'];
   for(var i=0; i<ignorePaths.length; i++) {
-    watchPaths.push("!./" + ignorePaths[i] + '/**/*');
+    watchPaths.push('!./' + ignorePaths[i] + '/**/*');
   }
 
   var open = (argv.o) ? true : false;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "send": "^0.6.0",
     "tiny-lr": "^0.1.5"
   },
+  "scripts": {
+    "test": "mocha --reporter spec"
+  },
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -25,5 +28,8 @@
       "type": "MIT",
       "url": "http://github.com/wearefractal/lute/raw/master/LICENSE"
     }
-  ]
+  ],
+  "devDependencies": {
+    "mocha": "^2.2.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "minimist": "^0.2.0",
     "open": "^0.0.5",
     "portfinder": "^0.2.1",
-    "replacestream": "^0.1.3",
     "send": "^0.6.0",
     "tiny-lr": "^0.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "repository": "git://github.com/wearefractal/lute.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "dependencies": {
-    "gulp": "^3.8.6",
-    "gulp-util": "^2.2.0",
-    "minimist": "^0.2.0",
+    "gulp": "^3.9.0",
+    "gulp-util": "^2.2.20",
+    "minimist": "^1.1.0",
     "open": "^0.0.5",
     "portfinder": "^0.2.1",
     "send": "^0.6.0",
-    "tiny-lr": "^0.0.9"
+    "tiny-lr": "^0.1.5"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/test/parseOptions.js
+++ b/test/parseOptions.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var minimist = require('minimist');
 var parseOptions = require('../lib/util/parseOptions');
 var config = require('../lib/config');
 
@@ -27,11 +26,18 @@ describe('parseOptions', function () {
   });
 
   describe('custom lr port', function () {
-    var argv = { l: 2020 };
+    var argv = { l: 4040 };
 
     it('should change the live reload port', function () {
       var options = parseOptions(argv);
-      assert.equal(options.lrPort, 2020);
+      assert.equal(options.lrPort, 4040);
+    });
+  });
+
+  describe('open browser', function () {
+    it('should set open to true', function () {
+      var options = parseOptions({ o: true });
+      assert.equal(options.open, true);
     });
   });
 

--- a/test/parseOptions.js
+++ b/test/parseOptions.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+var minimist = require('minimist');
+var parseOptions = require('../lib/util/parseOptions');
+
+function checkIgnore(path) {
+  return '!./' + path + '/**/*';
+}
+
+describe('parseOptions', function () {
+  it('should use the defaults', function () {
+    var options = parseOptions({});
+
+    assert.equal(options.port, 8080);
+    assert.equal(options.lrPort, 35729);
+    assert.equal(options.open, false);
+    assert.equal(typeof options.watchPath, 'undefined');
+  });
+
+  describe('custom port', function () {
+    var argv = { p: 2020 };
+
+    it('should change the port', function () {
+      var options = parseOptions(argv);
+      assert.equal(options.port, 2020);
+    });
+  });
+
+  describe('custom lr port', function () {
+    var argv = { l: 2020 };
+
+    it('should change the live reload port', function () {
+      var options = parseOptions(argv);
+      assert.equal(options.lrPort, 2020);
+    });
+  });
+
+  describe('ignored paths', function () {
+    it('should ignore the path', function () {
+      var path = 'ignore_me';
+      var options = parseOptions({ i: path });
+      var index = options.watchPaths.length - 1;
+      assert.equal(options.watchPaths[index], checkIgnore(path));
+    });
+
+    it('should ignore multiple paths', function () {
+      var paths = 'ignore,these,paths';
+      var options = parseOptions({ i: paths });
+      var splitPaths = paths.split(',');
+
+      for(var i = 0; i < splitPaths.length; i++) {
+        var index = options.watchPaths.length - 1 - i;
+        var pathIndex = splitPaths.length - 1 - i;
+        var path = splitPaths[pathIndex];
+
+        assert.equal(options.watchPaths[index], checkIgnore(path));
+      }
+    });
+  });
+});

--- a/test/parseOptions.js
+++ b/test/parseOptions.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var minimist = require('minimist');
 var parseOptions = require('../lib/util/parseOptions');
+var config = require('../lib/config');
 
 function checkIgnore(path) {
   return '!./' + path + '/**/*';
@@ -10,8 +11,8 @@ describe('parseOptions', function () {
   it('should use the defaults', function () {
     var options = parseOptions({});
 
-    assert.equal(options.port, 8080);
-    assert.equal(options.lrPort, 35729);
+    assert.equal(options.port, config.httpPort);
+    assert.equal(options.lrPort, config.lrPort);
     assert.equal(options.open, false);
     assert.equal(typeof options.watchPath, 'undefined');
   });


### PR DESCRIPTION
- Move all options parsing to its own module
- Allow override of live-reload path
- Create tests around the option parser
- Bump dependency versions
- Update readme
- Whitespace changes (remove extraneous newlines, don't align equal signs)

Sorry this PR is so big, just figured I'd get it all updated in 1 shot and kept going. Hopefully the commit log helps.
